### PR TITLE
Feature/local sharding

### DIFF
--- a/src/Servus.Akka.Samples.WebApi/Actors/CounterActor.cs
+++ b/src/Servus.Akka.Samples.WebApi/Actors/CounterActor.cs
@@ -1,0 +1,34 @@
+using Akka.Actor;
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Samples.WebApi.Actors;
+
+public sealed record Increment(string EntityId) : IWithEntityId;
+public sealed record Decrement(string EntityId) : IWithEntityId;
+public sealed record GetCount(string EntityId) : IWithEntityId;
+public sealed record CounterValue(string EntityId, int Count);
+
+public class CounterActor : ReceiveActor
+{
+    private int _count;
+
+    public CounterActor(string entityId)
+    {
+        Receive<Increment>(_ =>
+        {
+            _count++;
+            Sender.Tell(new CounterValue(entityId, _count));
+        });
+
+        Receive<Decrement>(_ =>
+        {
+            _count--;
+            Sender.Tell(new CounterValue(entityId, _count));
+        });
+
+        Receive<GetCount>(_ =>
+        {
+            Sender.Tell(new CounterValue(entityId, _count));
+        });
+    }
+}

--- a/src/Servus.Akka.Samples.WebApi/Actors/LogForwarderActor.cs
+++ b/src/Servus.Akka.Samples.WebApi/Actors/LogForwarderActor.cs
@@ -1,0 +1,18 @@
+using System.Threading.Channels;
+using Akka.Actor;
+using Akka.Event;
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Samples.WebApi.Actors;
+
+public class LogForwarderActor : ReceiveActor
+{
+    public LogForwarderActor(ChannelWriter<string> writer)
+    {
+        Receive<Info>(msg =>
+        {
+            if (msg.LogClass == typeof(LocalEntityRegionActor))
+                writer.TryWrite($"[{msg.LogLevel()}] {msg.Message}");
+        });
+    }
+}

--- a/src/Servus.Akka.Samples.WebApi/Program.cs
+++ b/src/Servus.Akka.Samples.WebApi/Program.cs
@@ -1,0 +1,78 @@
+using System.Threading.Channels;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Servus.Akka;
+using Servus.Akka.Local;
+using Servus.Akka.Samples.WebApi.Actors;
+
+var logChannel = Channel.CreateBounded<string>(100);
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAkka("counter-system", akka =>
+{
+    akka.WithLocalEntityRegion<CounterActor>(
+        typeName: "counters",
+        entityPropsFactory: id => Props.Create(() => new CounterActor(id)),
+        messageExtractor: new EntityIdExtractor(),
+        options: new LocalEntityRegionOptions
+        {
+            PassivateIdleEntityAfter = TimeSpan.FromSeconds(20),
+            EntityIdStore = new FileEntityIdStore(Environment.SpecialFolder.CommonApplicationData, "servus.akka.samples.webapi")
+        });
+
+    akka.WithActors((system, _) =>
+    {
+        var forwarder = system.ActorOf(Props.Create(() => new LogForwarderActor(logChannel.Writer)));
+        system.EventStream.Subscribe(forwarder, typeof(Info));
+    });
+});
+
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+app.MapGet("/counters/{id}", async (string id, ActorSystem system) =>
+{
+    if (!LocalEntityRegionActor.IsValidEntityId(id))
+        return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
+
+    var region = system.GetActor<CounterActor>();
+    var result = await region.Ask<CounterValue>(new GetCount(id), TimeSpan.FromSeconds(5));
+    return Results.Ok(result);
+});
+
+app.MapPost("/counters/{id}/increment", async (string id, ActorSystem system) =>
+{
+    if (!LocalEntityRegionActor.IsValidEntityId(id))
+        return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
+
+    var region = system.GetActor<CounterActor>();
+    var result = await region.Ask<CounterValue>(new Increment(id), TimeSpan.FromSeconds(5));
+    return Results.Ok(result);
+});
+
+app.MapPost("/counters/{id}/decrement", async (string id, ActorSystem system) =>
+{
+    if (!LocalEntityRegionActor.IsValidEntityId(id))
+        return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
+
+    var region = system.GetActor<CounterActor>();
+    var result = await region.Ask<CounterValue>(new Decrement(id), TimeSpan.FromSeconds(5));
+    return Results.Ok(result);
+});
+
+app.MapGet("/logs", async (HttpContext ctx, CancellationToken ct) =>
+{
+    ctx.Response.ContentType = "text/event-stream";
+    var reader = logChannel.Reader;
+
+    await foreach (var line in reader.ReadAllAsync(ct))
+    {
+        await ctx.Response.WriteAsync($"data: {line}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+});
+
+app.Run();

--- a/src/Servus.Akka.Samples.WebApi/Program.cs
+++ b/src/Servus.Akka.Samples.WebApi/Program.cs
@@ -38,7 +38,7 @@ app.MapGet("/counters/{id}", async (string id, ActorSystem system) =>
     if (!LocalEntityRegionActor.IsValidEntityId(id))
         return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
 
-    var region = system.GetActor<CounterActor>();
+    var region = await system.GetActorAsync<CounterActor>();
     var result = await region.Ask<CounterValue>(new GetCount(id), TimeSpan.FromSeconds(5));
     return Results.Ok(result);
 });
@@ -48,7 +48,7 @@ app.MapPost("/counters/{id}/increment", async (string id, ActorSystem system) =>
     if (!LocalEntityRegionActor.IsValidEntityId(id))
         return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
 
-    var region = system.GetActor<CounterActor>();
+    var region = await system.GetActorAsync<CounterActor>();
     var result = await region.Ask<CounterValue>(new Increment(id), TimeSpan.FromSeconds(5));
     return Results.Ok(result);
 });
@@ -58,7 +58,7 @@ app.MapPost("/counters/{id}/decrement", async (string id, ActorSystem system) =>
     if (!LocalEntityRegionActor.IsValidEntityId(id))
         return Results.BadRequest(new { error = $"Invalid entity ID '{id}'" });
 
-    var region = system.GetActor<CounterActor>();
+    var region = await system.GetActorAsync<CounterActor>();
     var result = await region.Ask<CounterValue>(new Decrement(id), TimeSpan.FromSeconds(5));
     return Results.Ok(result);
 });
@@ -75,4 +75,4 @@ app.MapGet("/logs", async (HttpContext ctx, CancellationToken ct) =>
     }
 });
 
-app.Run();
+await app.RunAsync();

--- a/src/Servus.Akka.Samples.WebApi/Servus.Akka.Samples.WebApi.csproj
+++ b/src/Servus.Akka.Samples.WebApi/Servus.Akka.Samples.WebApi.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Hosting" Version="1.5.44" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Servus.Akka\Servus.Akka.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Servus.Akka.Samples.WebApi/appsettings.Development.json
+++ b/src/Servus.Akka.Samples.WebApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Servus.Akka.Samples.WebApi/appsettings.json
+++ b/src/Servus.Akka.Samples.WebApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Servus.Akka.Samples.WebApi/wwwroot/index.html
+++ b/src/Servus.Akka.Samples.WebApi/wwwroot/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Servus.Akka — Local Entity Region Demo</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, sans-serif; max-width: 600px; margin: 40px auto; padding: 0 20px; color: #1a1a1a; }
+        h1 { font-size: 1.4rem; margin-bottom: 24px; }
+        .controls { display: flex; gap: 8px; margin-bottom: 24px; }
+        input { flex: 1; padding: 8px 12px; border: 1px solid #ccc; border-radius: 4px; font-size: 1rem; }
+        button { padding: 8px 16px; border: none; border-radius: 4px; font-size: 0.9rem; cursor: pointer; background: #2563eb; color: #fff; }
+        button:hover { background: #1d4ed8; }
+        button.dec { background: #dc2626; }
+        button.dec:hover { background: #b91c1c; }
+        button.get { background: #059669; }
+        button.get:hover { background: #047857; }
+        .log { border: 1px solid #e5e7eb; border-radius: 4px; padding: 12px; min-height: 200px; max-height: 400px; overflow-y: auto; font-family: monospace; font-size: 0.85rem; background: #f9fafb; }
+        .log div { padding: 2px 0; border-bottom: 1px solid #f3f4f6; }
+        .log .error { color: #dc2626; }
+        .log .actor { color: #7c3aed; }
+    </style>
+</head>
+<body>
+    <h1>Local Entity Region — Counter Demo</h1>
+    <div class="controls">
+        <input type="text" id="entityId" placeholder="Entity ID (e.g. leberkas)" value="leberkas" />
+        <button class="get" onclick="send('get')">Get</button>
+        <button onclick="send('increment')">+1</button>
+        <button class="dec" onclick="send('decrement')">-1</button>
+    </div>
+    <div class="log" id="log"></div>
+
+    <script>
+        async function send(action) {
+            const id = document.getElementById('entityId').value.trim();
+            if (!id) return;
+
+            if (/[/#$]/.test(id) || !id.trim()) {
+                log(`Invalid entity ID '${id}' — must not contain '/', '#', '$'`, true);
+                return;
+            }
+
+            const method = action === 'get' ? 'GET' : 'POST';
+            const url = action === 'get'
+                ? `/counters/${encodeURIComponent(id)}`
+                : `/counters/${encodeURIComponent(id)}/${action}`;
+
+            try {
+                const res = await fetch(url, { method });
+                const data = await res.json();
+                if (data.error) {
+                    log(`${method} /counters/${id} → ${data.error}`, true);
+                    return;
+                }
+                log(`${method} /counters/${id} → ${data.entityId} = ${data.count}`);
+            } catch (e) {
+                log(`${method} ${url} → ERROR: ${e.message}`, true);
+            }
+        }
+
+        function log(msg, isError, isActor) {
+            const el = document.getElementById('log');
+            const line = document.createElement('div');
+            if (isError) line.className = 'error';
+            if (isActor) line.className = 'actor';
+            line.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+            el.prepend(line);
+        }
+
+        const events = new EventSource('/logs');
+        events.onmessage = (e) => log(e.data, false, true);
+    </script>
+</body>
+</html>

--- a/src/Servus.Akka.Tests/Local/EntityIdExtractorTests.cs
+++ b/src/Servus.Akka.Tests/Local/EntityIdExtractorTests.cs
@@ -1,0 +1,30 @@
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Tests.Local;
+
+public class EntityIdExtractorTests
+{
+    private readonly EntityIdExtractor _extractor = new();
+
+    [Fact]
+    public void ReturnsEntityIdFromIWithEntityIdMessage()
+    {
+        var message = new TestEntityMessage("entity-1", "hello");
+        Assert.Equal("entity-1", _extractor.EntityId(message));
+    }
+
+    [Fact]
+    public void ReturnsNullForMessageWithoutIWithEntityId()
+    {
+        Assert.Null(_extractor.EntityId("plain string"));
+    }
+
+    [Fact]
+    public void EntityMessageReturnsMessageAsIs()
+    {
+        var message = new TestEntityMessage("entity-1", "hello");
+        Assert.Same(message, _extractor.EntityMessage(message));
+    }
+
+    public sealed record TestEntityMessage(string EntityId, string Payload) : IWithEntityId;
+}

--- a/src/Servus.Akka.Tests/Local/FileEntityIdStoreTests.cs
+++ b/src/Servus.Akka.Tests/Local/FileEntityIdStoreTests.cs
@@ -1,0 +1,65 @@
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Tests.Local;
+
+public class FileEntityIdStoreTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), $"servus-test-{Guid.NewGuid()}");
+    private string StorePath => Path.Combine(_directory, "entities.store");
+
+    [Fact]
+    public async Task LoadReturnsEmptyWhenFileDoesNotExist()
+    {
+        var store = new FileEntityIdStore(_directory);
+        var entities = await store.LoadEntitiesAsync();
+        Assert.Empty(entities);
+    }
+
+    [Fact]
+    public async Task PersistsEntitiesToFile()
+    {
+        var store = new FileEntityIdStore(_directory);
+        await store.EntityStarted("entity-1");
+        await store.EntityStarted("entity-2");
+
+        Assert.True(File.Exists(StorePath));
+        var lines = await File.ReadAllLinesAsync(StorePath);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("entity-1", lines);
+        Assert.Contains("entity-2", lines);
+    }
+
+    [Fact]
+    public async Task SurvivesNewInstance()
+    {
+        var store1 = new FileEntityIdStore(_directory);
+        await store1.EntityStarted("entity-1");
+        await store1.EntityStarted("entity-2");
+
+        var store2 = new FileEntityIdStore(_directory);
+        var entities = await store2.LoadEntitiesAsync();
+
+        Assert.Equal(2, entities.Count);
+        Assert.Contains("entity-1", entities);
+        Assert.Contains("entity-2", entities);
+    }
+
+    [Fact]
+    public async Task StopRemovesFromFile()
+    {
+        var store = new FileEntityIdStore(_directory);
+        await store.EntityStarted("entity-1");
+        await store.EntityStarted("entity-2");
+        await store.EntityStopped("entity-1");
+
+        var lines = await File.ReadAllLinesAsync(StorePath);
+        Assert.Single(lines);
+        Assert.Contains("entity-2", lines);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, true);
+    }
+}

--- a/src/Servus.Akka.Tests/Local/InMemoryEntityIdStoreTests.cs
+++ b/src/Servus.Akka.Tests/Local/InMemoryEntityIdStoreTests.cs
@@ -1,0 +1,49 @@
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Tests.Local;
+
+public class InMemoryEntityIdStoreTests
+{
+    private readonly InMemoryEntityIdStore _store = new();
+
+    [Fact]
+    public async Task LoadReturnsEmptyInitially()
+    {
+        var entities = await _store.LoadEntitiesAsync();
+        Assert.Empty(entities);
+    }
+
+    [Fact]
+    public async Task StartedEntitiesAreLoadable()
+    {
+        await _store.EntityStarted("entity-1");
+        await _store.EntityStarted("entity-2");
+
+        var entities = await _store.LoadEntitiesAsync();
+        Assert.Equal(2, entities.Count);
+        Assert.Contains("entity-1", entities);
+        Assert.Contains("entity-2", entities);
+    }
+
+    [Fact]
+    public async Task StoppedEntitiesAreRemoved()
+    {
+        await _store.EntityStarted("entity-1");
+        await _store.EntityStarted("entity-2");
+        await _store.EntityStopped("entity-1");
+
+        var entities = await _store.LoadEntitiesAsync();
+        Assert.Single(entities);
+        Assert.Contains("entity-2", entities);
+    }
+
+    [Fact]
+    public async Task DuplicateStartIsIdempotent()
+    {
+        await _store.EntityStarted("entity-1");
+        await _store.EntityStarted("entity-1");
+
+        var entities = await _store.LoadEntitiesAsync();
+        Assert.Single(entities);
+    }
+}

--- a/src/Servus.Akka.Tests/Local/LocalEntityRegionTests.cs
+++ b/src/Servus.Akka.Tests/Local/LocalEntityRegionTests.cs
@@ -1,0 +1,263 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Servus.Akka.Local;
+
+namespace Servus.Akka.Tests.Local;
+
+public sealed record EntityMessage(string EntityId, string Payload) : IWithEntityId;
+
+public class EchoEntityActor : ReceiveActor
+{
+    public EchoEntityActor(string entityId)
+    {
+        Receive<EntityMessage>(msg => Sender.Tell(new EntityResponse(entityId, msg.Payload)));
+    }
+}
+
+public sealed record EntityResponse(string EntityId, string Payload);
+
+public class LocalEntityRegionTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalEntityRegion<EchoEntityActor>(
+            typeName: "echo",
+            entityPropsFactory: id => Props.Create(() => new EchoEntityActor(id)));
+    }
+
+    [Fact]
+    public void RoutesMessageToCorrectEntity()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-1", "hello"), TestActor);
+        var response = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("order-1", response.EntityId);
+        Assert.Equal("hello", response.Payload);
+    }
+
+    [Fact]
+    public void CreatesEntityOnFirstMessage()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-new", "first"), TestActor);
+        var response = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("order-new", response.EntityId);
+        Assert.Equal("first", response.Payload);
+    }
+
+    [Fact]
+    public void ReusesExistingEntity()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-1", "first"), TestActor);
+        var response1 = ExpectMsg<EntityResponse>();
+
+        region.Tell(new EntityMessage("order-1", "second"), TestActor);
+        var response2 = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("order-1", response1.EntityId);
+        Assert.Equal("order-1", response2.EntityId);
+        Assert.Equal("first", response1.Payload);
+        Assert.Equal("second", response2.Payload);
+    }
+
+    [Fact]
+    public void RoutesToDifferentEntities()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-1", "hello"), TestActor);
+        var r1 = ExpectMsg<EntityResponse>();
+
+        region.Tell(new EntityMessage("order-2", "world"), TestActor);
+        var r2 = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("order-1", r1.EntityId);
+        Assert.Equal("order-2", r2.EntityId);
+    }
+}
+
+public class LocalEntityRegionPassivationTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalEntityRegion<EchoEntityActor>(
+            typeName: "echo-passivate",
+            entityPropsFactory: id => Props.Create(() => new EchoEntityActor(id)),
+            messageExtractor: new EntityIdExtractor(),
+            options: new LocalEntityRegionOptions
+            {
+                PassivateIdleEntityAfter = TimeSpan.FromSeconds(1)
+            });
+    }
+
+    [Fact]
+    public async Task PassivatesIdleEntities()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-1", "hello"), TestActor);
+        ExpectMsg<EntityResponse>();
+
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        region.Tell(new EntityMessage("order-1", "after-passivation"), TestActor);
+        var response = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("order-1", response.EntityId);
+        Assert.Equal("after-passivation", response.Payload);
+    }
+}
+
+public class LocalEntityRegionRecoveryTests : TestKit
+{
+    private static readonly InMemoryEntityIdStore Store = new();
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        Store.EntityStarted("pre-existing-1").GetAwaiter().GetResult();
+        Store.EntityStarted("pre-existing-2").GetAwaiter().GetResult();
+
+        builder.WithLocalEntityRegion<EchoEntityActor>(
+            typeName: "echo-recover",
+            entityPropsFactory: id => Props.Create(() => new EchoEntityActor(id)),
+            messageExtractor: new EntityIdExtractor(),
+            options: new LocalEntityRegionOptions
+            {
+                EntityIdStore = Store
+            });
+    }
+
+    [Fact]
+    public void RecoveredEntitiesRespondToMessages()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("pre-existing-1", "hello"), TestActor);
+        var response = ExpectMsg<EntityResponse>();
+
+        Assert.Equal("pre-existing-1", response.EntityId);
+        Assert.Equal("hello", response.Payload);
+    }
+}
+
+public class LocalEntityRegionInvalidEntityIdTests : TestKit
+{
+    private class InvalidIdExtractor : IEntityIdExtractor
+    {
+        public string? EntityId(object message) => message as string;
+        public object EntityMessage(object message) => message;
+    }
+
+    public class SinkActor : ReceiveActor
+    {
+        public SinkActor(string entityId)
+        {
+            ReceiveAny(_ => Sender.Tell("ok"));
+        }
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalEntityRegion<SinkActor>(
+            typeName: "invalid-id",
+            entityPropsFactory: id => Props.Create(() => new SinkActor(id)),
+            messageExtractor: new InvalidIdExtractor());
+    }
+
+    [Theory]
+    [InlineData("order/1")]
+    [InlineData("order#1")]
+    [InlineData("order$1")]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void RejectsInvalidEntityIds(string invalidId)
+    {
+        var region = Sys.GetActor<SinkActor>();
+        region.Tell(invalidId, TestActor);
+        ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Fact]
+    public void AcceptsValidEntityIds()
+    {
+        var region = Sys.GetActor<SinkActor>();
+        region.Tell("order-1", TestActor);
+        ExpectMsg<string>("ok");
+    }
+}
+
+public class LocalEntityRegionPassivationRaceTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalEntityRegion<EchoEntityActor>(
+            typeName: "echo-race",
+            entityPropsFactory: id => Props.Create(() => new EchoEntityActor(id)),
+            messageExtractor: new EntityIdExtractor(),
+            options: new LocalEntityRegionOptions
+            {
+                PassivateIdleEntityAfter = TimeSpan.FromSeconds(1)
+            });
+    }
+
+    [Fact]
+    public async Task MessageDuringPassivationIsNotLost()
+    {
+        var region = Sys.GetActor<EchoEntityActor>();
+
+        region.Tell(new EntityMessage("order-1", "first"), TestActor);
+        ExpectMsg<EntityResponse>();
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        // Entity is passivating or just passivated — send message immediately
+        region.Tell(new EntityMessage("order-1", "after-race"), TestActor);
+        var response = ExpectMsg<EntityResponse>(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("order-1", response.EntityId);
+        Assert.Equal("after-race", response.Payload);
+    }
+}
+
+public class LocalEntityRegionCustomExtractorTests : TestKit
+{
+    private class CustomExtractor : IEntityIdExtractor
+    {
+        public string? EntityId(object message) => message is string s ? s.Split(':')[0] : null;
+        public object EntityMessage(object message) => message is string s ? s.Split(':')[1] : message;
+    }
+
+    public class StringEchoActor : ReceiveActor
+    {
+        public StringEchoActor(string entityId)
+        {
+            ReceiveAny(msg => Sender.Tell($"{entityId}:{msg}"));
+        }
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalEntityRegion<StringEchoActor>(
+            typeName: "custom-extract",
+            entityPropsFactory: id => Props.Create(() => new StringEchoActor(id)),
+            messageExtractor: new CustomExtractor());
+    }
+
+    [Fact]
+    public void UsesCustomExtractor()
+    {
+        var region = Sys.GetActor<StringEchoActor>();
+
+        region.Tell("order-1:hello", TestActor);
+        var response = ExpectMsg<string>();
+
+        Assert.Equal("order-1:hello", response);
+    }
+}

--- a/src/Servus.Akka.sln
+++ b/src/Servus.Akka.sln
@@ -11,19 +11,56 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.github\workflows\build-and-release.yml = ..\.github\workflows\build-and-release.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Servus.Akka.Samples.WebApi", "Servus.Akka.Samples.WebApi\Servus.Akka.Samples.WebApi.csproj", "{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|x64.Build.0 = Debug|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Debug|x86.Build.0 = Debug|Any CPU
 		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|x64.ActiveCfg = Release|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|x64.Build.0 = Release|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC30B88D-1E33-49BF-9867-058F63DBBB00}.Release|x86.Build.0 = Release|Any CPU
 		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Debug|x86.Build.0 = Debug|Any CPU
 		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|x64.Build.0 = Release|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D6A1F772-DF59-432E-B8CF-BFC037D2A14A}.Release|x86.Build.0 = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|x64.Build.0 = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|x64.ActiveCfg = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|x64.Build.0 = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{6C6CDCDE-6F89-4DA9-B7C8-9E34842F3B9B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/Servus.Akka/Local/EntityIdExtractor.cs
+++ b/src/Servus.Akka/Local/EntityIdExtractor.cs
@@ -1,0 +1,8 @@
+namespace Servus.Akka.Local;
+
+public class EntityIdExtractor : IEntityIdExtractor
+{
+    public string? EntityId(object message) => (message as IWithEntityId)?.EntityId;
+
+    public object EntityMessage(object message) => message;
+}

--- a/src/Servus.Akka/Local/FileEntityIdStore.cs
+++ b/src/Servus.Akka/Local/FileEntityIdStore.cs
@@ -5,7 +5,8 @@ public class FileEntityIdStore : IEntityIdStore
     private const string FileName = "entities.store";
 
     private readonly string _filePath;
-    private readonly HashSet<string> _entities = [];
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private HashSet<string> _entities = [];
 
     public FileEntityIdStore(string directory)
     {
@@ -19,17 +20,14 @@ public class FileEntityIdStore : IEntityIdStore
 
     public async Task<IReadOnlyCollection<string>> LoadEntitiesAsync()
     {
-        _entities.Clear();
-
         if (!File.Exists(_filePath))
+        {
+            _entities = [];
             return [];
+        }
 
         var lines = await File.ReadAllLinesAsync(_filePath);
-        foreach (var line in lines)
-        {
-            if (!string.IsNullOrWhiteSpace(line))
-                _entities.Add(line);
-        }
+        _entities = lines.Where(e => !string.IsNullOrWhiteSpace(e)).ToHashSet();
 
         return _entities.ToList();
     }
@@ -48,12 +46,20 @@ public class FileEntityIdStore : IEntityIdStore
 
     private async Task FlushAsync()
     {
-        var directory = Path.GetDirectoryName(_filePath);
-        if (directory is not null)
-            Directory.CreateDirectory(directory);
+        await _writeLock.WaitAsync();
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (directory is not null)
+                Directory.CreateDirectory(directory);
 
-        var tempPath = _filePath + ".tmp";
-        await File.WriteAllLinesAsync(tempPath, _entities);
-        File.Move(tempPath, _filePath, overwrite: true);
+            var tempPath = _filePath + ".tmp";
+            await File.WriteAllLinesAsync(tempPath, _entities);
+            File.Move(tempPath, _filePath, overwrite: true);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 }

--- a/src/Servus.Akka/Local/FileEntityIdStore.cs
+++ b/src/Servus.Akka/Local/FileEntityIdStore.cs
@@ -1,0 +1,59 @@
+namespace Servus.Akka.Local;
+
+public class FileEntityIdStore : IEntityIdStore
+{
+    private const string FileName = "entities.store";
+
+    private readonly string _filePath;
+    private readonly HashSet<string> _entities = [];
+
+    public FileEntityIdStore(string directory)
+    {
+        _filePath = Path.Combine(directory, FileName);
+    }
+
+    public FileEntityIdStore(Environment.SpecialFolder folder, string name)
+        : this(Path.Combine(Environment.GetFolderPath(folder), name))
+    {
+    }
+
+    public async Task<IReadOnlyCollection<string>> LoadEntitiesAsync()
+    {
+        _entities.Clear();
+
+        if (!File.Exists(_filePath))
+            return [];
+
+        var lines = await File.ReadAllLinesAsync(_filePath);
+        foreach (var line in lines)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+                _entities.Add(line);
+        }
+
+        return _entities.ToList();
+    }
+
+    public async Task EntityStarted(string entityId)
+    {
+        _entities.Add(entityId);
+        await FlushAsync();
+    }
+
+    public async Task EntityStopped(string entityId)
+    {
+        _entities.Remove(entityId);
+        await FlushAsync();
+    }
+
+    private async Task FlushAsync()
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (directory is not null)
+            Directory.CreateDirectory(directory);
+
+        var tempPath = _filePath + ".tmp";
+        await File.WriteAllLinesAsync(tempPath, _entities);
+        File.Move(tempPath, _filePath, overwrite: true);
+    }
+}

--- a/src/Servus.Akka/Local/IEntityIdExtractor.cs
+++ b/src/Servus.Akka/Local/IEntityIdExtractor.cs
@@ -1,0 +1,7 @@
+namespace Servus.Akka.Local;
+
+public interface IEntityIdExtractor
+{
+    string? EntityId(object message);
+    object EntityMessage(object message);
+}

--- a/src/Servus.Akka/Local/IEntityIdStore.cs
+++ b/src/Servus.Akka/Local/IEntityIdStore.cs
@@ -1,0 +1,8 @@
+namespace Servus.Akka.Local;
+
+public interface IEntityIdStore
+{
+    Task<IReadOnlyCollection<string>> LoadEntitiesAsync();
+    Task EntityStarted(string entityId);
+    Task EntityStopped(string entityId);
+}

--- a/src/Servus.Akka/Local/IWithEntityId.cs
+++ b/src/Servus.Akka/Local/IWithEntityId.cs
@@ -1,0 +1,6 @@
+namespace Servus.Akka.Local;
+
+public interface IWithEntityId
+{
+    string EntityId { get; }
+}

--- a/src/Servus.Akka/Local/InMemoryEntityIdStore.cs
+++ b/src/Servus.Akka/Local/InMemoryEntityIdStore.cs
@@ -1,0 +1,21 @@
+namespace Servus.Akka.Local;
+
+public class InMemoryEntityIdStore : IEntityIdStore
+{
+    private readonly HashSet<string> _entities = [];
+
+    public Task<IReadOnlyCollection<string>> LoadEntitiesAsync()
+        => Task.FromResult<IReadOnlyCollection<string>>(_entities.ToList());
+
+    public Task EntityStarted(string entityId)
+    {
+        _entities.Add(entityId);
+        return Task.CompletedTask;
+    }
+
+    public Task EntityStopped(string entityId)
+    {
+        _entities.Remove(entityId);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Servus.Akka/Local/LocalEntityRegionActor.cs
+++ b/src/Servus.Akka/Local/LocalEntityRegionActor.cs
@@ -1,22 +1,25 @@
 using Akka.Actor;
 using Akka.Event;
+using Servus.Core;
 
 namespace Servus.Akka.Local;
 
 public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
 {
-    private sealed record Initialize;
     private sealed record PassivationTick;
 
+    private const int MaxRestarts = 3;
     private static readonly char[] InvalidEntityIdChars = ['/', '#', '$'];
 
     private readonly Func<string, Props> _entityPropsFactory;
     private readonly IEntityIdExtractor _messageExtractor;
     private readonly IEntityIdStore _entityIdStore;
+    private readonly TimeProvider _timeProvider;
     private readonly TimeSpan? _passivateAfter;
 
     private readonly Dictionary<string, IActorRef> _entities = [];
     private readonly Dictionary<string, DateTime> _lastActivity = [];
+    private readonly Dictionary<string, int> _restartCounts = [];
     private readonly HashSet<string> _passivating = [];
 
     private readonly ILoggingAdapter _log = Context.GetLogger();
@@ -32,6 +35,7 @@ public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
         _entityPropsFactory = entityPropsFactory;
         _messageExtractor = messageExtractor;
         _entityIdStore = options?.EntityIdStore ?? new InMemoryEntityIdStore();
+        _timeProvider = options?.TimeProvider ?? TimeProvider.System;
         _passivateAfter = options?.PassivateIdleEntityAfter;
 
         Initializing();
@@ -40,7 +44,7 @@ public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
     protected override void PreStart()
     {
         base.PreStart();
-        Self.Tell(new Initialize());
+        _entityIdStore.LoadEntitiesAsync().PipeTo(Self);
     }
 
     protected override void PostStop()
@@ -51,39 +55,45 @@ public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
 
     private void Initializing()
     {
-        ReceiveAsync<Initialize>(async _ =>
+        Receive<IReadOnlyCollection<string>>(entities =>
         {
-            var entities = await _entityIdStore.LoadEntitiesAsync();
-            foreach (var entityId in entities)
+            entities.ForEach(e =>
             {
-                SpawnEntity(entityId);
-                _log.Info("Entity [{0}] recovered", entityId);
-            }
+                SpawnEntity(e, false);
+                _log.Info("Entity [{0}] recovered", e);
+            });
 
-            Become(Ready);
-            Stash.UnstashAll();
-            SchedulePassivation();
+            BecomeReady();
         });
+
+        Receive<Status.Failure>(f =>
+        {
+            _log.Error(f.Cause, "Failed to load entities from store");
+            BecomeReady();
+        });
+
         ReceiveAny(_ => Stash.Stash());
     }
 
-    private void Ready()
+    private void BecomeReady()
     {
-        ReceiveAsync<PassivationTick>(async _ => await RunPassivationAsync());
-        ReceiveAsync<Terminated>(async t => await HandleTerminatedAsync(t));
-        ReceiveAsync<object>(async msg => await RouteMessageAsync(msg));
+        
+        Become(() =>
+        {
+            Receive<PassivationTick>(_ => RunPassivation());
+            Receive<Terminated>(HandleTerminated);
+            Receive<Status.Failure>(f => _log.Error(f.Cause, "Entity store operation failed"));
+            Receive<object>(RouteMessage);
+        });
+        
+        Stash.UnstashAll();
+        SchedulePassivation();
     }
 
-    private async Task RouteMessageAsync(object message)
+    private void RouteMessage(object message)
     {
         var entityId = _messageExtractor.EntityId(message);
-        if (entityId is null)
-        {
-            Unhandled(message);
-            return;
-        }
-
-        if (!IsValidEntityId(entityId))
+        if (entityId is null || !IsValidEntityId(entityId))
         {
             _log.Warning("Invalid entity ID [{0}] — must not be empty or contain '/', '#', '$'", entityId);
             Unhandled(message);
@@ -96,59 +106,70 @@ public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
             return;
         }
 
-        var entityRef = await GetOrCreateEntityAsync(entityId);
-        _lastActivity[entityId] = DateTime.UtcNow;
+        var entityRef = GetOrCreateEntity(entityId);
+        _restartCounts.Remove(entityId);
+        _lastActivity[entityId] = _timeProvider.GetUtcNow().UtcDateTime;
         entityRef.Forward(_messageExtractor.EntityMessage(message));
     }
 
-    private async Task<IActorRef> GetOrCreateEntityAsync(string entityId)
+    private IActorRef GetOrCreateEntity(string entityId)
     {
         if (_entities.TryGetValue(entityId, out var existing))
             return existing;
 
         var child = SpawnEntity(entityId);
-        await _entityIdStore.EntityStarted(entityId);
         _log.Info("Entity [{0}] started", entityId);
         return child;
     }
 
-    private IActorRef SpawnEntity(string entityId)
+    private IActorRef SpawnEntity(string entityId, bool persist = true)
     {
+        if(persist) _entityIdStore.EntityStarted(entityId).PipeTo(Self);
+        
         var props = _entityPropsFactory(entityId);
         var child = Context.ActorOf(props, entityId);
         Context.Watch(child);
 
         _entities[entityId] = child;
-        _lastActivity[entityId] = DateTime.UtcNow;
+        _lastActivity[entityId] = _timeProvider.GetUtcNow().UtcDateTime;
         return child;
     }
 
-    private async Task HandleTerminatedAsync(Terminated terminated)
+    private void HandleTerminated(Terminated terminated)
     {
         var entityId = terminated.ActorRef.Path.Name;
-
-        if (_passivating.Remove(entityId))
-        {
-            _entities.Remove(entityId);
-            _lastActivity.Remove(entityId);
-            Stash.UnstashAll();
-            return;
-        }
 
         _entities.Remove(entityId);
         _lastActivity.Remove(entityId);
 
-        var child = SpawnEntity(entityId);
-        await _entityIdStore.EntityStarted(entityId);
-        _log.Warning("Entity [{0}] restarted after unexpected termination", entityId);
+        if (_passivating.Remove(entityId))
+        {
+            Stash.UnstashAll();
+            return;
+        }
+
+        if (Context.System.WhenTerminated.IsCompleted)
+            return;
+
+        var count = _restartCounts.GetValueOrDefault(entityId, 0) + 1;
+        if (count > MaxRestarts)
+        {
+            _log.Error("Entity [{0}] exceeded max restart attempts ({1}), giving up", entityId, MaxRestarts);
+            _restartCounts.Remove(entityId);
+            return;
+        }
+
+        _restartCounts[entityId] = count;
+        SpawnEntity(entityId);
+        _log.Warning("Entity [{0}] restarted after unexpected termination (attempt {1}/{2})", entityId, count, MaxRestarts);
     }
 
-    private async Task RunPassivationAsync()
+    private void RunPassivation()
     {
         if (_passivateAfter is not { } timeout)
             return;
 
-        var cutoff = DateTime.UtcNow - timeout;
+        var cutoff = _timeProvider.GetUtcNow().UtcDateTime - timeout;
         var toPassivate = _lastActivity
             .Where(kv => kv.Value < cutoff)
             .Select(kv => kv.Key)
@@ -160,7 +181,7 @@ public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
                 continue;
 
             _passivating.Add(entityId);
-            await _entityIdStore.EntityStopped(entityId);
+            _entityIdStore.EntityStopped(entityId).PipeTo(Self);
             _log.Info("Entity [{0}] passivating (idle for {1})", entityId, _passivateAfter);
             Context.Stop(actorRef);
         }

--- a/src/Servus.Akka/Local/LocalEntityRegionActor.cs
+++ b/src/Servus.Akka/Local/LocalEntityRegionActor.cs
@@ -1,0 +1,184 @@
+using Akka.Actor;
+using Akka.Event;
+
+namespace Servus.Akka.Local;
+
+public class LocalEntityRegionActor : ReceiveActor, IWithUnboundedStash
+{
+    private sealed record Initialize;
+    private sealed record PassivationTick;
+
+    private static readonly char[] InvalidEntityIdChars = ['/', '#', '$'];
+
+    private readonly Func<string, Props> _entityPropsFactory;
+    private readonly IEntityIdExtractor _messageExtractor;
+    private readonly IEntityIdStore _entityIdStore;
+    private readonly TimeSpan? _passivateAfter;
+
+    private readonly Dictionary<string, IActorRef> _entities = [];
+    private readonly Dictionary<string, DateTime> _lastActivity = [];
+    private readonly HashSet<string> _passivating = [];
+
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private ICancelable? _passivationTimer;
+
+    public IStash Stash { get; set; } = null!;
+
+    public LocalEntityRegionActor(
+        Func<string, Props> entityPropsFactory,
+        IEntityIdExtractor messageExtractor,
+        LocalEntityRegionOptions? options = null)
+    {
+        _entityPropsFactory = entityPropsFactory;
+        _messageExtractor = messageExtractor;
+        _entityIdStore = options?.EntityIdStore ?? new InMemoryEntityIdStore();
+        _passivateAfter = options?.PassivateIdleEntityAfter;
+
+        Initializing();
+    }
+
+    protected override void PreStart()
+    {
+        base.PreStart();
+        Self.Tell(new Initialize());
+    }
+
+    protected override void PostStop()
+    {
+        _passivationTimer?.Cancel();
+        base.PostStop();
+    }
+
+    private void Initializing()
+    {
+        ReceiveAsync<Initialize>(async _ =>
+        {
+            var entities = await _entityIdStore.LoadEntitiesAsync();
+            foreach (var entityId in entities)
+            {
+                SpawnEntity(entityId);
+                _log.Info("Entity [{0}] recovered", entityId);
+            }
+
+            Become(Ready);
+            Stash.UnstashAll();
+            SchedulePassivation();
+        });
+        ReceiveAny(_ => Stash.Stash());
+    }
+
+    private void Ready()
+    {
+        ReceiveAsync<PassivationTick>(async _ => await RunPassivationAsync());
+        ReceiveAsync<Terminated>(async t => await HandleTerminatedAsync(t));
+        ReceiveAsync<object>(async msg => await RouteMessageAsync(msg));
+    }
+
+    private async Task RouteMessageAsync(object message)
+    {
+        var entityId = _messageExtractor.EntityId(message);
+        if (entityId is null)
+        {
+            Unhandled(message);
+            return;
+        }
+
+        if (!IsValidEntityId(entityId))
+        {
+            _log.Warning("Invalid entity ID [{0}] — must not be empty or contain '/', '#', '$'", entityId);
+            Unhandled(message);
+            return;
+        }
+
+        if (_passivating.Contains(entityId))
+        {
+            Stash.Stash();
+            return;
+        }
+
+        var entityRef = await GetOrCreateEntityAsync(entityId);
+        _lastActivity[entityId] = DateTime.UtcNow;
+        entityRef.Forward(_messageExtractor.EntityMessage(message));
+    }
+
+    private async Task<IActorRef> GetOrCreateEntityAsync(string entityId)
+    {
+        if (_entities.TryGetValue(entityId, out var existing))
+            return existing;
+
+        var child = SpawnEntity(entityId);
+        await _entityIdStore.EntityStarted(entityId);
+        _log.Info("Entity [{0}] started", entityId);
+        return child;
+    }
+
+    private IActorRef SpawnEntity(string entityId)
+    {
+        var props = _entityPropsFactory(entityId);
+        var child = Context.ActorOf(props, entityId);
+        Context.Watch(child);
+
+        _entities[entityId] = child;
+        _lastActivity[entityId] = DateTime.UtcNow;
+        return child;
+    }
+
+    private async Task HandleTerminatedAsync(Terminated terminated)
+    {
+        var entityId = terminated.ActorRef.Path.Name;
+
+        if (_passivating.Remove(entityId))
+        {
+            _entities.Remove(entityId);
+            _lastActivity.Remove(entityId);
+            Stash.UnstashAll();
+            return;
+        }
+
+        _entities.Remove(entityId);
+        _lastActivity.Remove(entityId);
+
+        var child = SpawnEntity(entityId);
+        await _entityIdStore.EntityStarted(entityId);
+        _log.Warning("Entity [{0}] restarted after unexpected termination", entityId);
+    }
+
+    private async Task RunPassivationAsync()
+    {
+        if (_passivateAfter is not { } timeout)
+            return;
+
+        var cutoff = DateTime.UtcNow - timeout;
+        var toPassivate = _lastActivity
+            .Where(kv => kv.Value < cutoff)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        foreach (var entityId in toPassivate)
+        {
+            if (!_entities.TryGetValue(entityId, out var actorRef))
+                continue;
+
+            _passivating.Add(entityId);
+            await _entityIdStore.EntityStopped(entityId);
+            _log.Info("Entity [{0}] passivating (idle for {1})", entityId, _passivateAfter);
+            Context.Stop(actorRef);
+        }
+    }
+
+    private void SchedulePassivation()
+    {
+        if (_passivateAfter is not { } timeout)
+            return;
+
+        var interval = TimeSpan.FromSeconds(Math.Max(timeout.TotalSeconds / 2, 1));
+        _passivationTimer = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
+            interval, interval, Self, new PassivationTick(), ActorRefs.NoSender);
+    }
+
+    public static bool IsValidEntityId(string entityId)
+    {
+        return !string.IsNullOrWhiteSpace(entityId)
+               && entityId.AsSpan().IndexOfAny(InvalidEntityIdChars) < 0;
+    }
+}

--- a/src/Servus.Akka/Local/LocalEntityRegionOptions.cs
+++ b/src/Servus.Akka/Local/LocalEntityRegionOptions.cs
@@ -1,0 +1,7 @@
+namespace Servus.Akka.Local;
+
+public class LocalEntityRegionOptions
+{
+    public TimeSpan? PassivateIdleEntityAfter { get; set; }
+    public IEntityIdStore? EntityIdStore { get; set; }
+}

--- a/src/Servus.Akka/Local/LocalEntityRegionOptions.cs
+++ b/src/Servus.Akka/Local/LocalEntityRegionOptions.cs
@@ -4,4 +4,5 @@ public class LocalEntityRegionOptions
 {
     public TimeSpan? PassivateIdleEntityAfter { get; set; }
     public IEntityIdStore? EntityIdStore { get; set; }
+    public TimeProvider? TimeProvider { get; set; }
 }

--- a/src/Servus.Akka/LocalEntityRegionExtensions.cs
+++ b/src/Servus.Akka/LocalEntityRegionExtensions.cs
@@ -1,0 +1,62 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Servus.Akka.Local;
+
+namespace Servus.Akka;
+
+public static class LocalEntityRegionExtensions
+{
+    public static AkkaConfigurationBuilder WithLocalEntityRegion<TKey>(
+        this AkkaConfigurationBuilder builder,
+        string typeName,
+        Func<string, Props> entityPropsFactory)
+    {
+        return builder.WithLocalEntityRegion<TKey>(
+            typeName, entityPropsFactory, new EntityIdExtractor());
+    }
+
+    public static AkkaConfigurationBuilder WithLocalEntityRegion<TKey>(
+        this AkkaConfigurationBuilder builder,
+        string typeName,
+        Func<string, Props> entityPropsFactory,
+        IEntityIdExtractor messageExtractor)
+    {
+        return builder.WithLocalEntityRegion<TKey>(
+            typeName, entityPropsFactory, messageExtractor, new LocalEntityRegionOptions());
+    }
+
+    public static AkkaConfigurationBuilder WithLocalEntityRegion<TKey>(
+        this AkkaConfigurationBuilder builder,
+        string typeName,
+        Func<string, Props> entityPropsFactory,
+        IEntityIdExtractor messageExtractor,
+        LocalEntityRegionOptions options)
+    {
+        return builder.WithActors((system, registry) =>
+        {
+            var props = Props.Create(() =>
+                new LocalEntityRegionActor(entityPropsFactory, messageExtractor, options));
+
+            var regionRef = system.ActorOf(props, typeName);
+            registry.Register<TKey>(regionRef);
+        });
+    }
+
+    public static AkkaConfigurationBuilder WithLocalEntityRegion<TKey>(
+        this AkkaConfigurationBuilder builder,
+        string typeName,
+        Func<ActorSystem, IActorRegistry, Func<string, Props>> entityPropsFactory,
+        IEntityIdExtractor messageExtractor,
+        LocalEntityRegionOptions options)
+    {
+        return builder.WithActors((system, registry) =>
+        {
+            var propsFactory = entityPropsFactory(system, registry);
+            var props = Props.Create(() =>
+                new LocalEntityRegionActor(propsFactory, messageExtractor, options));
+
+            var regionRef = system.ActorOf(props, typeName);
+            registry.Register<TKey>(regionRef);
+        });
+    }
+}


### PR DESCRIPTION
## Motivation

Akka.NET Cluster Sharding is powerful but comes with significant operational overhead — it requires running a cluster, configuring distributed data or persistence for shard coordination, and managing cluster membership. For many applications, especially smaller services or local development, you just need the actor-per-entity pattern (one actor instance per entity ID, messages routed by ID) without the distributed infrastructure.

### What it does

- LocalEntityRegionActor — a parent actor that manages child actors keyed by entity ID. It extracts the entity ID from incoming messages, creates child actors on demand, and forwards the unwrapped message.
- Idle passivation — optionally stops entities that have been idle for a configurable duration, reclaiming resources.
- Entity recovery — persists known entity IDs via a pluggable IEntityIdStore (in-memory or file-backed) and restores them on startup.
- Restart supervision — automatically restarts unexpectedly terminated entities up to a configurable limit.
- Stashing during init & passivation — messages arriving before the region is ready or while an entity is passivating are stashed and replayed, so no messages are lost.
- Akka.Hosting integration — WithLocalEntityRegion<TKey>() extension methods for fluent registration, mirroring the WithShardRegion API.